### PR TITLE
Fix bad event id when content includes unicode characters

### DIFF
--- a/src/Message/EventMessage.php
+++ b/src/Message/EventMessage.php
@@ -24,7 +24,7 @@ class EventMessage implements MessageInterface
      */
     public function generate(): string
     {
-        return '["EVENT", ' . json_encode($this->event->toArray(), JSON_UNESCAPED_SLASHES) . ']';
+        return '["EVENT", ' . json_encode($this->event->toArray(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . ']';
     }
 
 }

--- a/src/Sign/Sign.php
+++ b/src/Sign/Sign.php
@@ -25,7 +25,7 @@ class Sign
         $hash_content = $this->serializeEvent($event);
         if ($hash_content)
         {
-            $id = hash('sha256', utf8_encode($hash_content));
+            $id = hash('sha256', $hash_content);
             $event->setId($id);
 
             $sign = new SchnorrSignature();

--- a/src/Sign/Sign.php
+++ b/src/Sign/Sign.php
@@ -52,7 +52,7 @@ class Sign
             $event->getTags(),
             $event->getContent(),
         ];
-        return json_encode($array, JSON_UNESCAPED_SLASHES);
+        return json_encode($array, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
 }


### PR DESCRIPTION
When running `json_encode` AFTER the event is signed, we have to deter it from escaping unicode characters or it changes the message content, which invalidates the event id.

Fixes #23 