### PR TITLE
Run test suite on each push to GH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: push
+
+jobs:
+  run-tests:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["8.1", "8.2"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+      - run: composer install
+      - run: php vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # nostr-php
 
+![CI](https://github.com/swentel/nostr-php/actions/workflows/ci.yml/badge.svg)
 ![Packagist PHP Version](https://img.shields.io/packagist/dependency-v/swentel/nostr-php/php)
 ![GitHub contributors](https://img.shields.io/github/contributors/swentel/nostr-php)
 ![GitHub issues](https://img.shields.io/github/issues/swentel/nostr-php)


### PR DESCRIPTION
Simple GitHub action that clones the project, installs the dependencies and runs the test suite. It tests each supported version of PHP in parallel.

Setting up a code coverage badge is possible but a bit trickier than in GitLab. It involves either generating the badge as an SVG file on each run of the pipeline and committing it to the repo automatically (a bit ugly IMO), or uploading the coverage information to a third party service. Here you can see an example of the latter option:

https://github.com/1ma/jimmy#programming-bitcoin
https://scrutinizer-ci.com/g/1ma/jimmy/code-structure/master/code-coverage/src/

I can set that up if you want, too. For now I've left it out because of the introduction of a 3rd party dependency.