### PR TITLE
Enforce coding standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,5 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
       - run: composer install
+      - run: php vendor/bin/php-cs-fixer check -v
       - run: php vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/vendor
-.phpunit.cache
+.idea/
+.php-cs-fixer.cache
+.phpunit.cache/
 composer.lock
 test.php
-.idea
+vendor/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__ . '/bin',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+return (new PhpCsFixer\Config())
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PER-CS' => true,
+        '@PER-CS:risky' => true,
+    ]);

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,4 +15,5 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PER-CS' => true,
         '@PER-CS:risky' => true,
+        'declare_strict_types' => true,
     ]);

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "phrity/websocket": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10"
+        "phpunit/phpunit": "^10",
+        "friendsofphp/php-cs-fixer": "^3.35"
     },
     "autoload": {
         "psr-4": {
@@ -22,5 +23,8 @@
     },
     "bin": [
         "bin/nostr-php"
-    ]
+    ],
+    "scripts": {
+        "lint": "@php vendor/bin/php-cs-fixer fix -v"
+    }
 }

--- a/src/Application/Client.php
+++ b/src/Application/Client.php
@@ -7,8 +7,8 @@ use swentel\nostr\Message\EventMessage;
 use swentel\nostr\Relay\Relay;
 use swentel\nostr\Sign\Sign;
 
-Class Client {
-
+class Client
+{
     /**
      * Run the Nostr Client.
      *
@@ -23,18 +23,15 @@ Class Client {
 
         $content = $socket = $private_key_file = '';
 
-        if (count($args) != 7)
-        {
+        if (count($args) !== 7) {
             $this->showHelp('Missing arguments');
             return;
         }
 
-        foreach ($args as $current_key => $value)
-        {
-            switch ($value)
-            {
+        foreach ($args as $current_key => $value) {
+            switch ($value) {
                 case '--content':
-                    $array_key = $current_key+1;
+                    $array_key = $current_key + 1;
                     $content = trim($args[$array_key]);
                     break;
                 case '--relay':
@@ -48,33 +45,28 @@ Class Client {
             }
         }
 
-        if (empty($content))
-        {
+        if (empty($content)) {
             $this->showHelp('The content is empty');
             return;
         }
 
-        if (empty($socket))
-        {
+        if (empty($socket)) {
             $this->showHelp('The relay is empty');
             return;
         }
 
-        if (empty($private_key_file))
-        {
+        if (empty($private_key_file)) {
             $this->showHelp('The path to the private key is empty');
             return;
         }
 
-        if (!file_exists($private_key_file))
-        {
+        if (!file_exists($private_key_file)) {
             $this->showHelp('The private key file does not exist');
             return;
         }
 
         $private_key = trim(file_get_contents($private_key_file));
-        if (empty($private_key))
-        {
+        if (empty($private_key)) {
             $this->showHelp('The private key file is empty');
             return;
         }
@@ -89,15 +81,11 @@ Class Client {
         $eventMessage = new EventMessage($event);
         $relay = new Relay($socket, $eventMessage);
         $result = $relay->send();
-        if ($result->isSuccess())
-        {
+        if ($result->isSuccess()) {
             print "Send to Nostr!\n";
-        }
-        else
-        {
+        } else {
             print "Something went wrong: " . $result->message() . "\n";
         }
-
     }
 
     protected function showHelp($message): void

--- a/src/Application/Client.php
+++ b/src/Application/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr\Application;
 
 use swentel\nostr\Event\Event;

--- a/src/CommandResultInterface.php
+++ b/src/CommandResultInterface.php
@@ -2,8 +2,8 @@
 
 namespace swentel\nostr;
 
-interface CommandResultInterface {
-
+interface CommandResultInterface
+{
     /**
      * Returns whether the request was successful.
      *
@@ -24,5 +24,4 @@ interface CommandResultInterface {
      * @return string
      */
     public function getEventId(): string;
-
 }

--- a/src/CommandResultInterface.php
+++ b/src/CommandResultInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr;
 
 interface CommandResultInterface

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -7,7 +7,6 @@ use swentel\nostr\EventInterface;
 
 class Event implements EventInterface
 {
-
     /**
      * The event kind.
      *
@@ -134,7 +133,7 @@ class Event implements EventInterface
      */
     public function getKind(): int
     {
-       return $this->kind;
+        return $this->kind;
     }
 
     /**
@@ -206,8 +205,7 @@ class Event implements EventInterface
     {
         $array = [];
         foreach (get_object_vars($this) as $key => $val) {
-            if (in_array($key, $ignore_properties))
-            {
+            if (in_array($key, $ignore_properties)) {
                 continue;
             }
             $array[$key] = $val;
@@ -273,16 +271,19 @@ class Event implements EventInterface
         }
 
         try {
-            $computedId = hash('sha256', json_encode(
-                [
-                  0,
-                  $event->pubkey,
-                  $event->created_at,
-                  $event->kind,
-                  $event->tags,
-                  $event->content
-                ],
-                \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE)
+            $computedId = hash(
+                'sha256',
+                json_encode(
+                    [
+                      0,
+                      $event->pubkey,
+                      $event->created_at,
+                      $event->kind,
+                      $event->tags,
+                      $event->content
+                    ],
+                    \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE
+                )
             );
         } catch (\JsonException) {
             return false;

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr\Event;
 
 use Mdanter\Ecc\Crypto\Signature\SchnorrSignature;

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr;
 
 interface EventInterface

--- a/src/EventInterface.php
+++ b/src/EventInterface.php
@@ -4,7 +4,6 @@ namespace swentel\nostr;
 
 interface EventInterface
 {
-
     /**
      * Set the id.
      *

--- a/src/Key/Key.php
+++ b/src/Key/Key.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr\Key;
 
 use BitWasp\Bech32\Exception\Bech32Exception;

--- a/src/Key/Key.php
+++ b/src/Key/Key.php
@@ -4,6 +4,7 @@ namespace swentel\nostr\Key;
 
 use BitWasp\Bech32\Exception\Bech32Exception;
 use Elliptic\EC;
+
 use function BitWasp\Bech32\convertBits;
 use function BitWasp\Bech32\decode;
 use function BitWasp\Bech32\encode;
@@ -52,13 +53,12 @@ class Key
         try {
             $decoded = decode($key);
             $data = $decoded[1];
-            $bytes = convertBits($data, count($data), 5, 8, FALSE);
-            foreach ($bytes as $item)
-            {
+            $bytes = convertBits($data, count($data), 5, 8, false);
+            foreach ($bytes as $item) {
                 $str .= str_pad(dechex($item), 2, '0', STR_PAD_LEFT);
             }
+        } catch (Bech32Exception) {
         }
-        catch (Bech32Exception) {}
 
         return $str;
     }
@@ -107,10 +107,9 @@ class Key
             }
             $bytes = convertBits($dec, count($dec), 8, 5);
             $str = encode($prefix, $bytes);
+        } catch (Bech32Exception) {
         }
-        catch (Bech32Exception) {}
 
         return $str;
     }
-
 }

--- a/src/Message/EventMessage.php
+++ b/src/Message/EventMessage.php
@@ -7,7 +7,6 @@ use swentel\nostr\MessageInterface;
 
 class EventMessage implements MessageInterface
 {
-
     /**
      * The event.
      *
@@ -15,7 +14,8 @@ class EventMessage implements MessageInterface
      */
     protected EventInterface $event;
 
-    public function __construct(EventInterface $event) {
+    public function __construct(EventInterface $event)
+    {
         $this->event = $event;
     }
 
@@ -26,5 +26,4 @@ class EventMessage implements MessageInterface
     {
         return '["EVENT", ' . json_encode($this->event->toArray(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . ']';
     }
-
 }

--- a/src/Message/EventMessage.php
+++ b/src/Message/EventMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr\Message;
 
 use swentel\nostr\EventInterface;

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -4,12 +4,10 @@ namespace swentel\nostr;
 
 interface MessageInterface
 {
-
     /**
      * Generate the message ready to be sent to a relay.
      *
      * @return string
      */
     public function generate(): string;
-
 }

--- a/src/MessageInterface.php
+++ b/src/MessageInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr;
 
 interface MessageInterface

--- a/src/Relay/CommandResult.php
+++ b/src/Relay/CommandResult.php
@@ -6,13 +6,12 @@ use swentel\nostr\CommandResultInterface;
 
 class CommandResult implements CommandResultInterface
 {
-
     /**
      * Whether the request was successful or not.
      *
      * @var bool
      */
-    protected bool $success = FALSE;
+    protected bool $success = false;
 
     /**
      * The message.
@@ -35,8 +34,8 @@ class CommandResult implements CommandResultInterface
      */
     public function __construct(array $response)
     {
-        if ($response[0] === 'OK' && $response[2] === TRUE && !str_starts_with($response[3], 'duplicate:')) {
-            $this->success = TRUE;
+        if ($response[0] === 'OK' && $response[2] === true && !str_starts_with($response[3], 'duplicate:')) {
+            $this->success = true;
             $this->eventId = $response[1];
         } else {
             $this->message = !empty($response[3]) ? $response[3] : 'Failed with no reason';
@@ -48,7 +47,7 @@ class CommandResult implements CommandResultInterface
      */
     public function isSuccess(): bool
     {
-        return $this->success === TRUE;
+        return $this->success === true;
     }
 
     /**
@@ -66,5 +65,4 @@ class CommandResult implements CommandResultInterface
     {
         return $this->eventId;
     }
-
 }

--- a/src/Relay/CommandResult.php
+++ b/src/Relay/CommandResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr\Relay;
 
 use swentel\nostr\CommandResultInterface;

--- a/src/Relay/Relay.php
+++ b/src/Relay/Relay.php
@@ -9,7 +9,6 @@ use WebSocket;
 
 class Relay implements RelayInterface
 {
-
     /**
      * The relay URL.
      *
@@ -30,7 +29,7 @@ class Relay implements RelayInterface
      * @param string $websocket
      *   The socket URL.
      */
-    function __construct(string $websocket, MessageInterface $message)
+    public function __construct(string $websocket, MessageInterface $message)
     {
         // TODO validate URL.
         $this->url = $websocket;
@@ -42,7 +41,7 @@ class Relay implements RelayInterface
      */
     public function getUrl(): string
     {
-      return $this->url;
+        return $this->url;
     }
 
     /**
@@ -50,23 +49,23 @@ class Relay implements RelayInterface
      */
     public function send(): CommandResultInterface
     {
-      try {
-        $client = new WebSocket\Client($this->url);
-        $client->text($this->payload);
-        $response = $client->receive();
-        $client->close();
-        $response = json_decode($response);
-        if ($response[0] === 'NOTICE') {
-          throw new \RuntimeException($response[1]);
+        try {
+            $client = new WebSocket\Client($this->url);
+            $client->text($this->payload);
+            $response = $client->receive();
+            $client->close();
+            $response = json_decode($response);
+            if ($response[0] === 'NOTICE') {
+                throw new \RuntimeException($response[1]);
+            }
+        } catch (WebSocket\ConnectionException $e) {
+            $response = [
+              'ERROR',
+              '',
+              false,
+              $e->getMessage()
+            ];
         }
-      } catch (WebSocket\ConnectionException $e) {
-        $response = [
-          'ERROR',
-          '',
-          false,
-          $e->getMessage()
-        ];
-      }
-      return new CommandResult($response);
+        return new CommandResult($response);
     }
 }

--- a/src/Relay/Relay.php
+++ b/src/Relay/Relay.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr\Relay;
 
 use swentel\nostr\MessageInterface;

--- a/src/RelayInterface.php
+++ b/src/RelayInterface.php
@@ -2,8 +2,8 @@
 
 namespace swentel\nostr;
 
-interface RelayInterface {
-
+interface RelayInterface
+{
     /**
      * Get url of the relay.
      *
@@ -17,5 +17,4 @@ interface RelayInterface {
      * @return CommandResultInterface
      */
     public function send(): CommandResultInterface;
-
 }

--- a/src/RelayInterface.php
+++ b/src/RelayInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr;
 
 interface RelayInterface

--- a/src/Sign/Sign.php
+++ b/src/Sign/Sign.php
@@ -8,7 +8,6 @@ use swentel\nostr\Key\Key;
 
 class Sign
 {
-
     /**
      * Sign an event.
      *
@@ -22,13 +21,12 @@ class Sign
         $key = new Key();
         // Convert to hex if private key is bech32 formatted.
         if (str_starts_with($private_key, 'nsec') === true) {
-          $private_key = $key->convertToHex($private_key);
+            $private_key = $key->convertToHex($private_key);
         }
         $event->setPublicKey($key->getPublicKey($private_key));
 
         $hash_content = $this->serializeEvent($event);
-        if ($hash_content)
-        {
+        if ($hash_content) {
             $id = hash('sha256', $hash_content);
             $event->setId($id);
 
@@ -58,5 +56,4 @@ class Sign
         ];
         return json_encode($array, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
-
 }

--- a/src/Sign/Sign.php
+++ b/src/Sign/Sign.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace swentel\nostr\Sign;
 
 use Mdanter\Ecc\Crypto\Signature\SchnorrSignature;

--- a/tests/ConvertTest.php
+++ b/tests/ConvertTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use swentel\nostr\Key\Key;
 

--- a/tests/ConvertTest.php
+++ b/tests/ConvertTest.php
@@ -36,7 +36,5 @@ class ConvertTest extends TestCase
             $private_key_bech32,
             $keys->convertPrivateKeyToBech32($private_key_hex),
         );
-
     }
-
 }

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -19,5 +19,4 @@ class GenerateTest extends TestCase
             $keys->getPublicKey($private_key_hex),
         );
     }
-
 }

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use swentel\nostr\Key\Key;
 

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use swentel\nostr\Event\Event;
 use swentel\nostr\Key\Key;

--- a/tests/RelayTest.php
+++ b/tests/RelayTest.php
@@ -26,12 +26,11 @@ class RelayTest extends TestCase
         $relay = $this->createMock(Relay::class);
         $relay->expects($this->once())
             ->method('send')
-            ->willReturn(new CommandResult(['OK', $note->getId(), TRUE, '']));
+            ->willReturn(new CommandResult(['OK', $note->getId(), true, '']));
 
         $response = $relay->send();
         $this->assertTrue(
             $response->isSuccess()
         );
-
     }
 }

--- a/tests/SerializeTest.php
+++ b/tests/SerializeTest.php
@@ -16,11 +16,10 @@ class SerializeTest extends TestCase
 
         $sign = new Sign();
         $arrays = [];
-        $arrays['[0,"' . $public_key . '",'. $time . ',1,[],"Content\n\nwith new lines\nAnd quotes: \'"]'] = ['content' => "Content\n\nwith new lines\nAnd quotes: '"];
-        $arrays['[0,"' . $public_key . '",'. $time . ',1,[],"https://example.com/url"]'] = ['content' => "https://example.com/url"];
+        $arrays['[0,"' . $public_key . '",' . $time . ',1,[],"Content\n\nwith new lines\nAnd quotes: \'"]'] = ['content' => "Content\n\nwith new lines\nAnd quotes: '"];
+        $arrays['[0,"' . $public_key . '",' . $time . ',1,[],"https://example.com/url"]'] = ['content' => "https://example.com/url"];
 
-        foreach ($arrays as $expected => $source)
-        {
+        foreach ($arrays as $expected => $source) {
             $note = new Event();
             $note->setCreatedAt($time);
             $note->setPublicKey($public_key);
@@ -35,5 +34,4 @@ class SerializeTest extends TestCase
             );
         }
     }
-
 }

--- a/tests/SerializeTest.php
+++ b/tests/SerializeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use swentel\nostr\Event\Event;
 use swentel\nostr\Sign\Sign;

--- a/tests/VerifyTest.php
+++ b/tests/VerifyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use swentel\nostr\Event\Event;
 use swentel\nostr\Message\EventMessage;


### PR DESCRIPTION
[As discussed](https://github.com/swentel/nostr-php/pull/36#issuecomment-1772915955), this PR forces the project to follow the [PER Coding Style 2.0](https://www.php-fig.org/per/coding-style/) standard using the new CI pipeline.

I chose php-cs-fixer over phpcs because it can automatically format the code, not just detect violations. I chose the PER standard because it's not very opinionated compared to Symfony or PhpCsFixer's own ruleset. The actual rules applied by each ruleset can be browsed [here](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/master/doc/ruleSets).

As a development convenience I also introduced a `composer lint` command to easily format the code from the command line.

## Strict Types

We could take this opportunity to force the declaration of strict types on all classes (`'declare_strict_types' => true`). It's not strictly a backwards-compatible change (if existing users of nostr-php are not calling some methods of the library correctly), but strict types straight out prevent whole hosts of bugs.

I think strict types are always worth it, but I left them out of the PR for now. I'd like other people's input on this.