### PR TITLE
Use phrity/websocket instead of textalk/websocket

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "public-square/phpecc": "^0.1.0",
         "bitwasp/bech32": "^0.0.1",
         "simplito/elliptic-php": "^1.0",
-        "textalk/websocket": "^1.6"
+        "phrity/websocket": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10"


### PR DESCRIPTION
textalk/websocket is no longer supported. [phrity/websocket](https://github.com/sirn-se/websocket-php) is a fork and it has been more recently maintained.

See https://github.com/Textalk/websocket-php/pull/191