### PR TITLE
Fix event verifying (by useing 1ma/secp256k1-nostr-php)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "public-square/phpecc": "^0.1.0",
         "bitwasp/bech32": "^0.0.1",
         "simplito/elliptic-php": "^1.0",
-        "phrity/websocket": "^2.1.0"
+        "phrity/websocket": "^2.1.0",
+        "uma/secp256k1-nostr": "^0.1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^10",

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace swentel\nostr\Event;
 
-use Mdanter\Ecc\Crypto\Signature\SchnorrSignature;
 use swentel\nostr\EventInterface;
 
 class Event implements EventInterface
@@ -295,7 +294,7 @@ class Event implements EventInterface
             return false;
         }
 
-      return (new SchnorrSignature())->verify($event->pubkey, $event->sig, $event->id);
+        return secp256k1_nostr_verify($event->pubkey, $event->id, $event->sig);
     }
 
 }


### PR DESCRIPTION
Event verifying doesn't seem to work properly currently. Use this package fixes that, it is a php extension and does need to be installed manually tho.