### PR TITLE
Use forked public-square/phpecc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["8.1", "8.2"]
+        php-version: ["8.1", "8.2", "8.3"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}

--- a/composer.json
+++ b/composer.json
@@ -1,47 +1,50 @@
 {
-    "name": "swentel/nostr-php",
-    "description": "Nostr helper library for PHP",
-    "homepage": "https://github.com/swentel/nostr-php",
-    "license": "GPL-2.0-or-later",
-    "authors": [
-      {
-        "name": "Sebastian Hagens",
-        "email": "info@sebastix.nl",
-        "homepage": "https://sebastix.nl",
-        "role": "Developer & maintainer"
-      },
-      {
-        "name": "Kristof De Jaeger",
-        "role": "Original author",
-        "homepage": "https://realize.be"
-      }
-    ],
-    "support": {
-      "issue": "https://github.com/swentel/nostr-php/issues",
-      "chat": "https://t.me/nostr_php"
+  "name": "swentel/nostr-php",
+  "description": "Nostr helper library for PHP",
+  "homepage": "https://github.com/swentel/nostr-php",
+  "license": "GPL-2.0-or-later",
+  "authors": [
+    {
+      "name": "Sebastian Hagens",
+      "email": "info@sebastix.nl",
+      "homepage": "https://sebastix.nl",
+      "role": "Developer & maintainer"
     },
-    "require": {
-        "php": "^8.1",
-        "ext-gmp": "*",
-        "ext-xml": "*",
-        "public-square/phpecc": "^0.1.0",
-        "bitwasp/bech32": "^0.0.1",
-        "simplito/elliptic-php": "^1.0",
-        "phrity/websocket": "^2.1.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^10",
-        "friendsofphp/php-cs-fixer": "^3.35"
-    },
-    "autoload": {
-        "psr-4": {
-            "swentel\\nostr\\": "src/"
-        }
-    },
-    "bin": [
-        "bin/nostr-php"
-    ],
-    "scripts": {
-        "lint": "@php vendor/bin/php-cs-fixer fix -v"
+    {
+      "name": "Kristof De Jaeger",
+      "role": "Original author",
+      "homepage": "https://realize.be"
     }
+  ],
+  "support": {
+    "issue": "https://github.com/swentel/nostr-php/issues",
+    "chat": "https://t.me/nostr_php"
+  },
+  "require": {
+    "php": "^8.1",
+    "ext-gmp": "*",
+    "ext-xml": "*",
+    "bitwasp/bech32": "^0.0.1",
+    "phrity/websocket": "^2.1",
+    "simplito/elliptic-php": "^1.0",
+    "uma/phpecc": "^0.1.3"
+  },
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3.51",
+    "phpunit/phpunit": "^10.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "swentel\\nostr\\": "src/"
+    }
+  },
+  "bin": [
+    "bin/nostr-php"
+  ],
+  "config": {
+    "sort-packages": true
+  },
+  "scripts": {
+    "lint": "@php vendor/bin/php-cs-fixer fix -v"
+  }
 }

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -295,7 +295,7 @@ class Event implements EventInterface
             return false;
         }
 
-      return (new SchnorrSignature())->verify($event->pubkey, $event->sig, $event->id);
+        return (new SchnorrSignature())->verify($event->pubkey, $event->sig, $event->id);
     }
 
 }


### PR DESCRIPTION
Solves issue https://github.com/swentel/nostr-php/issues/49 and supersedes PR https://github.com/swentel/nostr-php/pull/50

Should be reverted back once https://github.com/public-square/phpecc/pull/1 is merged and tagged in `public-square/phpecc`.

I also sneaked in:

- a run of the linter (touched Event.php)
- normalization of the composer.json file to 2 spaces
- `config.sort-packages: true` in composer.json
- updated `actions/checkout` to v4
- start testing the lib on PHP 8.3