### PR TITLE
fix: allow php 8.3.1 etc. as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "chat": "https://t.me/nostr_php"
   },
   "require": {
-    "php": ">=8.1 <=8.3",
+    "php": ">=8.1 <8.4",
     "ext-gmp": "*",
     "ext-xml": "*",
     "bitwasp/bech32": "^0.0.1",


### PR DESCRIPTION
I was not able to install this on a system with php 8.3.1 due to the composer requirement. I am assuming `<= 8.3` was intended to allow 8.3.1 as well, so I changed it to `< 8.4`